### PR TITLE
Add Option#getE and Option.allObject

### DIFF
--- a/test/option.js
+++ b/test/option.js
@@ -1,7 +1,7 @@
 "use strict";
 exports.__esModule = true;
 var expect = require("expect");
-require("../all");
+require("../commonjs/all");
 var __1 = require("..");
 suite('option', function () {
     // isDefined
@@ -30,6 +30,14 @@ suite('option', function () {
         var none = __1.Option(undefined);
         expect(none.isDefined()).toBe(false);
         expect(none.get()).toBe(undefined);
+    });
+    test('Manipulating a None', function () {
+        var none = __1.None;
+        var anOption = none;
+        var x = none.get();
+        var y = anOption.get();
+        x;
+        y;
     });
     // forEach
     test('Some.forEach', function () {
@@ -148,36 +156,73 @@ suite('option', function () {
         expect(result instanceof __1.ArrayOps).toBe(true);
         expect(result.value()).toEqual([]);
     });
+    // toResult
+    test('Some.toResult', function () {
+        var result = __1.Option(10).toResult(function () { return 'nope'; });
+        expect(result.isOk() && result.get()).toBe(10);
+    });
+    test('None.toResult', function () {
+        var result = __1.Option(null).toResult(function () { return 'error'; });
+        expect(!result.isOk() && result.get()).toBe('error');
+    });
     // Option.all
     test('Option.all - 2 Some', function () {
-        var some = __1.Option.all(__1.Option('a'), __1.Option('b'));
+        var some = __1.Option.all([__1.Option('a'), __1.Option('b')]);
         expect(some.isDefined() && some.get().join(',') === 'a,b').toBe(true);
     });
     test('Option.all - 1 Some, 1 defined value', function () {
-        var some = __1.Option.all(__1.Option('a'), 'b');
+        var some = __1.Option.all([__1.Option('a'), 'b']);
         expect(some.isDefined() && some.get().join(',') === 'a,b').toBe(true);
     });
     test('Option.all - 3 Some', function () {
-        var some = __1.Option.all(__1.Option('a'), __1.Option('b'), __1.Option('c'));
+        var some = __1.Option.all([__1.Option('a'), __1.Option('b'), __1.Option('c')]);
         expect(some.isDefined() && some.get().join(',') === 'a,b,c').toBe(true);
     });
     test('Option.all - 1 Some, 1 None', function () {
-        var none = __1.Option.all(__1.Option('a'), __1.Option(undefined));
+        var none = __1.Option.all([__1.Option('a'), __1.Option(undefined)]);
         expect(!none.isDefined() && none.get() === undefined).toBe(true);
     });
     test('Option.all - 1 Some, 1 undefined', function () {
-        var none = __1.Option.all(__1.Option('a'), undefined);
+        var none = __1.Option.all([__1.Option('a'), undefined]);
         expect(!none.isDefined() && none.get() === undefined).toBe(true);
     });
     test('Option.all - values in the result tuple are refined to be non nullable', function () {
         var nullableString = 'a';
-        __1.Option.all(__1.Option(nullableString), undefined, nullableString).map(function (_a) {
+        __1.Option.all([__1.Option(nullableString), undefined, nullableString]).map(function (_a) {
             var a = _a[0], b = _a[1], c = _a[2];
             // Just testing the compilation here
             a.charCodeAt(10);
             c.charCodeAt(10);
             return 0;
         });
+    });
+    test('Option.all - 10 Some', function () {
+        var result = __1.Option.all([__1.Some(1), __1.Some('2'), __1.Some(3), __1.Some('4'), __1.Some(5), __1.Some(true), __1.Some(7), __1.Some(8), __1.Some(9), __1.Some(10)]);
+        var result2 = __1.Option.all([__1.Some(1), __1.Some('2'), __1.Some(3), __1.Some('4'), __1.Some(5), __1.Some(true)]);
+        expect(result.isDefined() && result.get()[2] + result.get()[9] === 13).toBe(true);
+        expect(result.get()).toEqual([1, '2', 3, '4', 5, true, 7, 8, 9, 10]);
+        expect(result2.isDefined() && result2.get()[0] + result2.get()[4] === 6).toBe(true);
+    });
+    // Option.allObject
+    test('Option.allObject - 2 Some', function () {
+        var some = __1.Option.allObject({ a: __1.Some('a'), b: __1.Some('b') });
+        expect(some.isDefined()).toBe(true);
+        expect(some.get()).toEqual({ a: 'a', b: 'b' });
+    });
+    test('Option.allObject - 1 Some, 1 None', function () {
+        var some = __1.Option.allObject({ a: __1.Some('a'), b: __1.None });
+        expect(some).toEqual(__1.None);
+    });
+    test('Option.allObject - values in the result have correct inference', function () {
+        var some = __1.Option.allObject({
+            a: __1.Some('a'),
+            b: __1.Some(2),
+            c: __1.Some([1, 2, 3])
+        });
+        // Just testing typechecker here
+        some.getE().a;
+        some.getE().b;
+        some.getE().c;
     });
     // Option.isOption
     test('Option.isOption', function () {

--- a/test/option.ts
+++ b/test/option.ts
@@ -278,6 +278,32 @@ suite('option', () => {
   })
 
 
+  // Option.allObject
+
+  test('Option.allObject - 2 Some', () => {
+    const some = Option.allObject({a: Some('a'), b: Some('b')});
+    expect(some.isDefined()).toBe(true);
+    expect(some.get()).toEqual({a: 'a', b: 'b'});
+  });
+
+  test('Option.allObject - 1 Some, 1 None', () => {
+    const some = Option.allObject({a: Some('a'), b: None});
+    expect(some).toEqual(None);
+  });
+
+  test('Option.allObject - values in the result have correct inference', () => {
+    const some = Option.allObject({
+      a: Some('a'),
+      b: Some(2),
+      c: Some([1, 2, 3]),
+    });
+    // Just testing typechecker here
+    (some.getE().a as string);
+    (some.getE().b as number);
+    (some.getE().c as number[]);
+  });
+
+
   // Option.isOption
 
   test('Option.isOption', () => {

--- a/test/result.js
+++ b/test/result.js
@@ -1,9 +1,9 @@
 "use strict";
 exports.__esModule = true;
 var expect = require("expect");
-require("../all");
+require("../commonjs/all");
 var __1 = require("..");
-suite('option', function () {
+suite('result', function () {
     // Type checking
     test('An Ok can be assigned to any Result with a compatible Ok type', function () {
         var result = __1.Ok(10);
@@ -82,21 +82,47 @@ suite('option', function () {
         var err = __1.Err(10).fold(function (err) { return 20; }, function (val) { return 30; });
         expect(err).toBe(20);
     });
+    // toOption
+    test('Ok.toOption', function () {
+        var option = __1.Ok(10).toOption();
+        expect(option.isDefined() && option.get()).toBe(10);
+    });
+    test('Err.toOption', function () {
+        var option = __1.Err('error').toOption();
+        expect(option.isDefined()).toBe(false);
+    });
     // Result.all
     test('Result.all - 2 Ok', function () {
-        var result = __1.Result.all(__1.Ok(10), __1.Ok('20'));
+        var result = __1.Result.all([
+            __1.Ok(10),
+            __1.Ok('20')
+        ]);
         expect(result.isOk()).toBe(true);
         expect(result.get()).toEqual([10, '20']);
     });
     test('Result.all - 1 Ok, 1 Err', function () {
-        var result = __1.Result.all(__1.Ok(10), __1.Err('20'));
+        var result = __1.Result.all([
+            __1.Ok(10),
+            __1.Err('20')
+        ]);
         expect(result.isOk()).toBe(false);
         expect(result.get()).toEqual('20');
     });
     test('Result.all - 1 Ok, 2 Err', function () {
-        var result = __1.Result.all(__1.Ok(10), __1.Err('20'), __1.Err({ error: 'oops' }));
+        var result = __1.Result.all([
+            __1.Ok(10),
+            __1.Err('20'),
+            __1.Err({ error: 'oops' })
+        ]);
         expect(result.isOk()).toBe(false);
         expect(result.get()).toEqual('20');
+    });
+    test('Result.all - 10 Ok', function () {
+        var result = __1.Result.all([__1.Ok(1), __1.Ok('2'), __1.Ok(3), __1.Ok('4'), __1.Ok(5), __1.Ok(true), __1.Ok(7), __1.Ok(8), __1.Ok(9), __1.Ok(10)]);
+        var result2 = __1.Result.all([__1.Ok(1), __1.Ok('2'), __1.Ok(3), __1.Ok('4'), __1.Ok(5), __1.Ok(true)]);
+        expect(result.get()[2] + result.get()[9] === 13).toBe(true);
+        expect(result.get()).toEqual([1, '2', 3, '4', 5, true, 7, 8, 9, 10]);
+        expect(result2.get()[0] + result2.get()[4] === 6).toBe(true);
     });
     // test('should not compile', () => {
     //   const test1 = Ok(10).flatMap(x => Ok(String(x * 2)))


### PR DESCRIPTION
Adds two methods:
- Function `allObject`, which transforms an object (map) of Options to an Option of object type
- Instance method `getE`, which returns interior value or throws