### PR TITLE
fix option implicit json

### DIFF
--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -289,7 +289,7 @@ _Some.prototype = {
   },
 
   toJSON() {
-    return this.value
+    return this.value.toJSON ? this.value.toJSON() : this.value
   }
 }
 

--- a/test/option.ts
+++ b/test/option.ts
@@ -326,6 +326,11 @@ suite('option', () => {
     expect(obj.x).toBe(10)
   })
 
+  test('Some toJSON with implicit json for contained object', () => {
+    const obj = JSON.parse(JSON.stringify({ x: Option({ toJSON() { return 10} }) }))
+    expect(obj.x).toBe(10)
+  })
+
   test('None toJSON', () => {
     const obj = JSON.parse(JSON.stringify({ x: Option(undefined) }))
     expect(obj.x).toBe(null)


### PR DESCRIPTION
Hello !

Thanks for `space-lift` 👍 

When a `Some` is serialized it currently does not call the json conversion of its value if it has one.

This PR fixes that by modifying the `toJSON` of `Option`

Note: I did not commit the js files generated by the tests. Should I ?