### PR TITLE
[improvement] use readonly array

### DIFF
--- a/src/lift.ts
+++ b/src/lift.ts
@@ -21,7 +21,7 @@ export interface Lift {
   (obj: Date): DateOps
 
   /** Wraps an Array to provide a richer API. Unwrap with .value() **/
-  <T>(obj: T[]): ArrayOps<T>
+  <T>(obj: ReadonlyArray<T>): ArrayOps<T>
 
   /** Wraps a plain Object to provide a richer API. Unwrap with .value() **/
   <T extends {}>(obj: T): ObjectOps<T>

--- a/test/test.ts
+++ b/test/test.ts
@@ -293,7 +293,7 @@ describe('lift', () => {
     })
 
     it('can be sorted', () => {
-      let sorted: any[], arr: any[]
+      let sorted: ReadonlyArray<any>, arr: ReadonlyArray<any>
 
       // Numbers
       arr = [5, 4, 1, 6, 2, 4, 3]

--- a/wrapper.d.ts
+++ b/wrapper.d.ts
@@ -9,7 +9,7 @@ export interface Wrapper<A> {
 
 
 export interface ArrayOpsConstructor {
-  new<A>(value: A[]): ArrayOps<A>
+  new<A>(value: ReadonlyArray<A>): ArrayOps<A>
   readonly prototype: ArrayOps<any>
 }
 


### PR DESCRIPTION
Hello ! 

currently `lift` takes a simple array `T[]` as argument which can be annoying when we use a `ReadonlyArray` because it forces the user to make an ugly cast (`lift(foo as string[])` with foo a ReadonlyArray) or a copy (`lift([...foo])`).

 I think using a `ReadonlyArray<T>` would also make it clearer that space-lift does not modify the value.

This PR only modify the input of the lift function, which should not be a problem for api compatibility (it actually makes the api less restrictive). The return of `value()` is still a normal array.

