### PR TITLE
[FIX] Object values typing

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -59,7 +59,7 @@ export class ObjectWrapper<T extends object> {
   /**
    * Creates an Array with all these object's values.
    */
-  values(): ArrayWrapper<Array<keyof T>> {
+  values(): ArrayWrapper<Array<T[keyof T]>> {
     return this.pipe(Object.values)
   }
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -56,6 +56,9 @@ describe('Object', () => {
     const result = lift(obj).values().sort().value()
     expect(result).not.toBe(obj)
     expect(result).toEqual([1, 2, 3])
+
+    // Type assertion
+    const _array: number[] = result
   })
 
   it("can return whether it's empty", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,10 +1531,6 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-immupdate@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/immupdate/-/immupdate-1.3.0.tgz#3070d0279823d29c70168a18334c892fced43a89"
-
 import-local@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"


### PR DESCRIPTION
Correct the ObjectWrapper.values() typing, it was returning the types of the keys.