### PR TITLE
fix: update "updateIf" types to prevent usage with primitive values

### DIFF
--- a/src/immupdate.ts
+++ b/src/immupdate.ts
@@ -165,6 +165,7 @@ export function clone<T extends object>(obj: T) {
   }
 }
 
+type NonPrimitiveGuard<T, Err extends string> = T extends string | number | boolean ? Err : T
 type Key = string | number
 type DraftCache = Record<Key, object | undefined>
 type MutateFunction = (mutation: () => void, changedKey: Key | {}) => void
@@ -239,7 +240,13 @@ interface DraftArray<T> {
    * If it returns true, a Draft item is created and  given to updateFunction, ready to be mutated.
    */
   updateIf(
-    predicate: (item: T, index: number) => boolean,
+    predicate: (
+      item: NonPrimitiveGuard<
+        T,
+        "TypeError: item is a primitive; use 'updateIf' with non-primitive types only"
+      >,
+      index: number
+    ) => boolean,
     updateFunction: (item: Draft<T>, index: number) => NoReturn
   ): void
 


### PR DESCRIPTION
Since using the `updateIf` function with primitives has no effect, this PR updates the TS types accordingly to warn users at the call site.

```ts
const example = update(['one', 'two'], words =>
  words.updateIf(
    word => word === 'one', // This comparison appears to be unintentional because the types '"TypeError: item is a primitive; use 'updateIf' with non-primitive types only"' and '"one"' have no overlap
    word => {
      word.toUpperCase()
    }
  )
)
```
